### PR TITLE
Added g:vitality_always_assume_iterm option

### DIFF
--- a/doc/vitality.txt
+++ b/doc/vitality.txt
@@ -23,15 +23,16 @@
 ==============================================================================
 CONTENTS                                                   *vitality-contents*
 
-    1. Overview and Usage .............. |VitalityOverview|
-    2. Configuration ................... |VitalityConfig|
-        2.1 g:vitality_fix_cursor ...... |vitality_fix_cursor|
-        2.2 g:vitality_fix_focus ....... |vitality_fix_focus|
-    3. How it Works .................... |VitalityHow|
-    4. License ......................... |VitalityLicense|
-    5. Bugs ............................ |VitalityBugs|
-    6. Contributing .................... |VitalityContributing|
-    7. Changelog ....................... |VitalityChangelog|
+    1. Overview and Usage ................... |VitalityOverview|
+    2. Configuration ........................ |VitalityConfig|
+        2.1 g:vitality_fix_cursor ........... |vitality_fix_cursor|
+        2.2 g:vitality_fix_focus ............ |vitality_fix_focus|
+        2.3 g:vitality_always_assume_iterm .. |vitality_always_assume_iterm|
+    3. How it Works ......................... |VitalityHow|
+    4. License .............................. |VitalityLicense|
+    5. Bugs ................................. |VitalityBugs|
+    6. Contributing ......................... |VitalityContributing|
+    7. Changelog ............................ |VitalityChangelog|
 
 ==============================================================================
 1. Overview and Usage                       *VitalityOverview* *VitalityUsage*
@@ -56,10 +57,11 @@ sometimes break.
 2. Configuration                                              *VitalityConfig*
 
 You can tweak the behavior of Vitality by setting a few variables in your
-:vimrc file. Currently two options are available: >
+.vimrc file. Currently three options are available: >
 
     let g:vitality_fix_cursor = 0
     let g:vitality_fix_focus = 0
+    let g:vitality_always_assume_iterm = 1
 
 ------------------------------------------------------------------------------
 2.1 g:vitality_fix_cursor                                *vitality_fix_cursor*
@@ -74,6 +76,21 @@ Default: 1
 Set this to 0 if you don't want focus events to be processed.
 
 Default: 1
+
+------------------------------------------------------------------------------
+2.3 g:vitality_always_assume_iterm              *vitality_always_assume_iterm*
+
+By default, Vitality only enables iTerm-specific features when $ITERM_PROFILE
+is present in your environment. However, this value is not preserved once
+you have connected by ssh to another system. If you only use iTerm2, you can
+tell Vim to always assume iTerm features will work.
+
+Set this to 1 if you want Vitality to always assume it is running in iTerm.
+
+Warning: if you set this to true and you run Vim from a terminal other
+than iTerm, it certainly will not work, and you may even get strange output.
+
+Default: depends on the existence of $ITERM_PROFILE.
 
 ==============================================================================
 3. How it Works                                                  *VitalityHow*

--- a/plugin/vitality.vim
+++ b/plugin/vitality.vim
@@ -24,7 +24,12 @@ if !exists('g:vitality_fix_focus') " {{{
     let g:vitality_fix_focus = 1
 endif " }}}
 
-let s:inside_iterm = exists('$ITERM_PROFILE')
+if exists('g:vitality_always_assume_iterm') " {{{
+    let s:inside_iterm = 1
+else
+    let s:inside_iterm = exists('$ITERM_PROFILE')
+endif " }}}
+
 let s:inside_tmux = exists('$TMUX')
 
 " }}}


### PR DESCRIPTION
As discussed in sjl/vitality.vim#10, Vitality is inert unless $ITERM_PROFILE is set, meaning that once you ssh to another system it doesn't do much of anything.

I suspect a huge chunk, if not the majority, of tmux sessions are on remote systems. I never use tmux locally, I use it remotely to preserve sessions in case I am cut off from the Internet, or to save sessions on a remote system that are still there after I sleep/wake my laptop.

(Yes, I am aware there are methods to connect a local tmux client to a remote tmux server, but I don't use them and I would guess a whole lot of tmux users do not use them.)

This pull request adds an option to tell Vitality to always assume iTerm is in use. It defaults to off, of course. I am always using iTerm anyway, and the same is _probably_ true of most iTerm users.

FWIW, I tested this in Terminal.app and while Vitality naturally didn't work, it didn't do anything weird (the escape codes were simply ignored as far as I can tell).
