### PR TITLE
Bug fix: cover case when currently in ^X mode, in insert mode.

### DIFF
--- a/plugin/vitality.vim
+++ b/plugin/vitality.vim
@@ -144,8 +144,8 @@ function! s:Vitality() " {{{
         vnoremap <silent> <f24> <esc>:silent doautocmd FocusLost %<cr>gv
         vnoremap <silent> <f25> <esc>:silent doautocmd FocusGained %<cr>gv
 
-        inoremap <silent> <f24> <c-o>:silent doautocmd FocusLost %<cr>
-        inoremap <silent> <f25> <c-o>:silent doautocmd FocusGained %<cr>
+        inoremap <silent> <f24> <c-\><c-o>:silent doautocmd FocusLost %<cr>
+        inoremap <silent> <f25> <c-\><c-o>:silent doautocmd FocusGained %<cr>
 
         cnoremap <silent> <f24> <c-\>e<SID>DoCmdFocusLost()<cr>
         cnoremap <silent> <f25> <c-\>e<SID>DoCmdFocusGained()<cr>


### PR DESCRIPTION
Hello,

To re-produce this bug:
1) Stay in ^X mode, omni-completion in this example.
![screenshot from 2017-01-29 14-43-23](https://cloud.githubusercontent.com/assets/4329951/22408731/7daf96f4-e632-11e6-94b0-a6553b98e4b6.png)
2) Switch to another pane, or another window outside of Tmux (example), then return to your Vim window.
![screenshot from 2017-01-29 14-45-40](https://cloud.githubusercontent.com/assets/4329951/22408732/7db221ee-e632-11e6-89bb-a6f9cdd06d5e.png)

This commit fixes the above behaviour.

Cheers,
Thaer