### PR TITLE
Added support for replace mode

### DIFF
--- a/doc/vitality.txt
+++ b/doc/vitality.txt
@@ -29,8 +29,9 @@ CONTENTS                                                   *vitality-contents*
         2.2 g:vitality_normal_cursor ........ |vitality_normal_cursor|
         2.3 g:vitality_insert_cursor ........ |vitality_insert_cursor|
         2.4 g:vitality_replace_cursor ....... |vitality_replace_cursor|
-        2.5 g:vitality_fix_focus ............ |vitality_fix_focus|
-        2.6 g:vitality_always_assume_iterm .. |vitality_always_assume_iterm|
+        2.5 g:vitality_shell_cursor ......... |vitality_replace_cursor|
+        2.6 g:vitality_fix_focus ............ |vitality_fix_focus|
+        2.7 g:vitality_always_assume_iterm .. |vitality_always_assume_iterm|
     3. How it Works ......................... |VitalityHow|
     4. License .............................. |VitalityLicense|
     5. Bugs ................................. |VitalityBugs|
@@ -66,6 +67,7 @@ You can tweak the behavior of Vitality by setting a few variables in your
     let g:vitality_normal_cursor = 0
     let g:vitality_insert_cursor = 1
     let g:vitality_replace_cursor = 2
+    let g:vitality_shell_cursor = 0
     let g:vitality_fix_focus = 0
     let g:vitality_always_assume_iterm = 1
 
@@ -120,14 +122,27 @@ Underline = 2
 Default: 2
 
 ------------------------------------------------------------------------------
-2.5 g:vitality_fix_focus                                  *vitality_fix_focus*
+2.5 g:vitality_shell_cursor                            *vitality_shell_cursor*
+
+Set this to the cursor type you want when you quit vim. This is useful for
+when you have your terminal's default shell cursor set to something other than
+the block. iTerm2 has three cursor types:
+
+Block = 0
+Bar = 1
+Underline = 2
+
+Default: 0
+
+------------------------------------------------------------------------------
+2.6 g:vitality_fix_focus                                  *vitality_fix_focus*
 
 Set this to 0 if you don't want focus events to be processed.
 
 Default: 1
 
 ------------------------------------------------------------------------------
-2.6 g:vitality_always_assume_iterm              *vitality_always_assume_iterm*
+2.7 g:vitality_always_assume_iterm              *vitality_always_assume_iterm*
 
 By default, Vitality only enables iTerm-specific features when $ITERM_PROFILE
 is present in your environment. However, this value is not preserved once

--- a/doc/vitality.txt
+++ b/doc/vitality.txt
@@ -28,8 +28,9 @@ CONTENTS                                                   *vitality-contents*
         2.1 g:vitality_fix_cursor ........... |vitality_fix_cursor|
         2.2 g:vitality_normal_cursor ........ |vitality_normal_cursor|
         2.3 g:vitality_insert_cursor ........ |vitality_insert_cursor|
-        2.4 g:vitality_fix_focus ............ |vitality_fix_focus|
-        2.5 g:vitality_always_assume_iterm .. |vitality_always_assume_iterm|
+        2.4 g:vitality_replace_cursor ....... |vitality_replace_cursor|
+        2.5 g:vitality_fix_focus ............ |vitality_fix_focus|
+        2.6 g:vitality_always_assume_iterm .. |vitality_always_assume_iterm|
     3. How it Works ......................... |VitalityHow|
     4. License .............................. |VitalityLicense|
     5. Bugs ................................. |VitalityBugs|
@@ -64,6 +65,7 @@ You can tweak the behavior of Vitality by setting a few variables in your
     let g:vitality_fix_cursor = 0
     let g:vitality_normal_cursor = 0
     let g:vitality_insert_cursor = 1
+    let g:vitality_replace_cursor = 2
     let g:vitality_fix_focus = 0
     let g:vitality_always_assume_iterm = 1
 
@@ -106,14 +108,26 @@ Underline = 2
 Default: 1
 
 ------------------------------------------------------------------------------
-2.4 g:vitality_fix_focus                                  *vitality_fix_focus*
+2.4 g:vitality_replace_cursor                        *vitality_replace_cursor*
+
+Set this to the cursor type you want to have in replace mode. iTerm2 has three
+cursor types:
+
+Block = 0
+Bar = 1
+Underline = 2
+
+Default: 2
+
+------------------------------------------------------------------------------
+2.5 g:vitality_fix_focus                                  *vitality_fix_focus*
 
 Set this to 0 if you don't want focus events to be processed.
 
 Default: 1
 
 ------------------------------------------------------------------------------
-2.5 g:vitality_always_assume_iterm              *vitality_always_assume_iterm*
+2.6 g:vitality_always_assume_iterm              *vitality_always_assume_iterm*
 
 By default, Vitality only enables iTerm-specific features when $ITERM_PROFILE
 is present in your environment. However, this value is not preserved once

--- a/plugin/vitality.vim
+++ b/plugin/vitality.vim
@@ -35,6 +35,9 @@ endif " }}}
 if !exists('g:vitality_insert_cursor') " {{{
     let g:vitality_insert_cursor = 1
 endif " }}}
+if !exists('g:vitality_replace_cursor') " {{{
+    let g:vitality_replace_cursor = 2
+endif " }}}
 
 if exists('g:vitality_always_assume_iterm') " {{{
     let s:inside_iterm = 1
@@ -76,8 +79,9 @@ function! s:Vitality() " {{{
     let restore_screen = "\<Esc>[?1049l"
 
     " These sequences tell iTerm2 to change the cursor shape.
-    let cursor_to_normal = "\<Esc>]50;CursorShape=" . g:vitality_normal_cursor . "\x7"
-    let cursor_to_insert = "\<Esc>]50;CursorShape=" . g:vitality_insert_cursor . "\x7"
+    let cursor_to_normal  = "\<Esc>]50;CursorShape=" . g:vitality_normal_cursor . "\x7"
+    let cursor_to_insert  = "\<Esc>]50;CursorShape=" . g:vitality_insert_cursor . "\x7"
+    let cursor_to_replace = "\<Esc>]50;CursorShape=" . g:vitality_replace_cursor . "\x7"
 
     if s:inside_tmux
         " Some escape sequences (but not all, lol) need to be properly escaped
@@ -88,6 +92,7 @@ function! s:Vitality() " {{{
 
         let cursor_to_normal = s:WrapForTmux(cursor_to_normal)
         let cursor_to_insert = s:WrapForTmux(cursor_to_insert)
+        let cursor_to_replace = s:WrapForTmux(cursor_to_replace)
     endif
 
     " }}}
@@ -111,7 +116,10 @@ function! s:Vitality() " {{{
         " When entering insert mode, change the cursor to the insert cursor.
         let &t_SI = cursor_to_insert . &t_SI
 
-        " When exiting insert mode, change it back to normal.
+        " When entering replace mode, change the cursor to the replace cursor.
+        let &t_SR = cursor_to_replace . &t_SR
+
+        " When exiting insert mode or replace mode, change it back to normal.
         let &t_EI = cursor_to_normal . &t_EI
     endif
 

--- a/plugin/vitality.vim
+++ b/plugin/vitality.vim
@@ -38,6 +38,9 @@ endif " }}}
 if !exists('g:vitality_replace_cursor') " {{{
     let g:vitality_replace_cursor = 2
 endif " }}}
+if !exists('g:vitality_shell_cursor') " {{{
+    let g:vitality_shell_cursor = 0
+endif " }}}
 
 if exists('g:vitality_always_assume_iterm') " {{{
     let s:inside_iterm = 1
@@ -82,6 +85,7 @@ function! s:Vitality() " {{{
     let cursor_to_normal  = "\<Esc>]50;CursorShape=" . g:vitality_normal_cursor . "\x7"
     let cursor_to_insert  = "\<Esc>]50;CursorShape=" . g:vitality_insert_cursor . "\x7"
     let cursor_to_replace = "\<Esc>]50;CursorShape=" . g:vitality_replace_cursor . "\x7"
+    let cursor_to_quit    = "\<Esc>]50;CursorShape=" . g:vitality_shell_cursor . "\x7"
 
     if s:inside_tmux
         " Some escape sequences (but not all, lol) need to be properly escaped
@@ -90,9 +94,10 @@ function! s:Vitality() " {{{
         let enable_focus_reporting = s:WrapForTmux(enable_focus_reporting) . enable_focus_reporting
         let disable_focus_reporting = disable_focus_reporting
 
-        let cursor_to_normal = s:WrapForTmux(cursor_to_normal)
-        let cursor_to_insert = s:WrapForTmux(cursor_to_insert)
+        let cursor_to_normal  = s:WrapForTmux(cursor_to_normal)
+        let cursor_to_insert  = s:WrapForTmux(cursor_to_insert)
         let cursor_to_replace = s:WrapForTmux(cursor_to_replace)
+        let cursor_to_quit    = s:WrapForTmux(cursor_to_quit)
     endif
 
     " }}}
@@ -121,6 +126,9 @@ function! s:Vitality() " {{{
 
         " When exiting insert mode or replace mode, change it back to normal.
         let &t_EI = cursor_to_normal . &t_EI
+
+        " When quitting vim restore cursor to the default.
+        let &t_te = cursor_to_quit . &t_te
     endif
 
     " }}}


### PR DESCRIPTION
Allows cursor shape to be changed when entering or leaving replace mode. I set the default cursor shape to the one that looks like an underscore because that is what gvim uses. I also modified the documentation to include information about the new options.