### PR TITLE
Ignore generated helptags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
Running `:helptags ALL` in Vim generates a tags file at doc/tags.